### PR TITLE
Bump the all group across 2 directories with 4 updates

### DIFF
--- a/exercisefiles/java_quarkus/pom.xml
+++ b/exercisefiles/java_quarkus/pom.xml
@@ -6,13 +6,13 @@
   <artifactId>copilot-demo</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <properties>
-    <compiler-plugin.version>3.13.0</compiler-plugin.version>
+    <compiler-plugin.version>3.14.0</compiler-plugin.version>
     <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.18.3</quarkus.platform.version>
+    <quarkus.platform.version>3.18.4</quarkus.platform.version>
     <skipITs>true</skipITs>
     <surefire-plugin.version>3.5.2</surefire-plugin.version>
   </properties>

--- a/exercisefiles/java_springboot/pom.xml
+++ b/exercisefiles/java_springboot/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.2</version>
+		<version>3.4.3</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.microsoft.hackathon</groupId>


### PR DESCRIPTION
Bumps the all group with 3 updates in the /exercisefiles/java_quarkus directory: [io.quarkus.platform:quarkus-bom](https://github.com/quarkusio/quarkus-platform), [io.quarkus.platform:quarkus-maven-plugin](https://github.com/quarkusio/quarkus-platform) and [org.apache.maven.plugins:maven-compiler-plugin](https://github.com/apache/maven-compiler-plugin).
Bumps the all group with 1 update in the /exercisefiles/java_springboot directory: [org.springframework.boot:spring-boot-starter-parent](https://github.com/spring-projects/spring-boot).


Updates `io.quarkus.platform:quarkus-bom` from 3.18.3 to 3.18.4
- [Commits](https://github.com/quarkusio/quarkus-platform/compare/3.18.3...3.18.4)

Updates `io.quarkus.platform:quarkus-maven-plugin` from 3.18.3 to 3.18.4
- [Commits](https://github.com/quarkusio/quarkus-platform/compare/3.18.3...3.18.4)

Updates `io.quarkus.platform:quarkus-maven-plugin` from 3.18.3 to 3.18.4
- [Commits](https://github.com/quarkusio/quarkus-platform/compare/3.18.3...3.18.4)

Updates `org.apache.maven.plugins:maven-compiler-plugin` from 3.13.0 to 3.14.0
- [Release notes](https://github.com/apache/maven-compiler-plugin/releases)
- [Commits](https://github.com/apache/maven-compiler-plugin/compare/maven-compiler-plugin-3.13.0...maven-compiler-plugin-3.14.0)

Updates `org.springframework.boot:spring-boot-starter-parent` from 3.4.2 to 3.4.3
- [Release notes](https://github.com/spring-projects/spring-boot/releases)
- [Commits](https://github.com/spring-projects/spring-boot/compare/v3.4.2...v3.4.3)

---
updated-dependencies:
- dependency-name: io.quarkus.platform:quarkus-bom dependency-type: direct:production update-type: version-update:semver-patch dependency-group: all
- dependency-name: io.quarkus.platform:quarkus-maven-plugin dependency-type: direct:production update-type: version-update:semver-patch dependency-group: all
- dependency-name: io.quarkus.platform:quarkus-maven-plugin dependency-type: direct:production update-type: version-update:semver-patch dependency-group: all
- dependency-name: org.apache.maven.plugins:maven-compiler-plugin dependency-type: direct:production update-type: version-update:semver-minor dependency-group: all
- dependency-name: org.springframework.boot:spring-boot-starter-parent dependency-type: direct:production update-type: version-update:semver-patch dependency-group: all ...