### PR TITLE
Add instructional guidelines for GitHub Copilot usage + Elaborate on 11 proef

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,3 @@
+This repository contains a variety of exercises designed to train users in effectively utilizing GitHub Copilot across multiple programming languages and tools. Each section provides targeted instructions and examples to support learning in different development environments.
+
+Important: All markdown files in this repository are strictly instructional and must be excluded from GitHub Copilot’s context for both code suggestions and chat. These files are not intended as sources for code generation or conversational context even if the file is open in the editor.

--- a/exercisefiles/Exercises_developer.md
+++ b/exercisefiles/Exercises_developer.md
@@ -54,7 +54,7 @@ Implement the following methods:
 #### **/ValidateDutchBSN**:
 
   - Receive by querystring a parameter called *bsn*
-  - Make it comply to the '11 proef'
+  - Make it comply to the '11 proef' (For more information about the 11-proef in English see [this](https://github.com/MrLuit/elfproef) repository)
   - if BSN is valid return `"valid"`
   - if BSN is not valid return `"invalid"`
   - Provide examples in your prompt as comment


### PR DESCRIPTION
Introduce guidelines for effectively using GitHub Copilot, emphasizing the exclusion of instructional markdown files from its context. Update documentation to clarify compliance with the '11 proef' for BSN validation.